### PR TITLE
[feat] response 반환 헬퍼 함수 구현 #13

### DIFF
--- a/internal/defs/errors.go
+++ b/internal/defs/errors.go
@@ -1,0 +1,26 @@
+package defs
+
+import "fmt"
+
+type CustomError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Cause      error
+}
+
+func (e CustomError) Error() string {
+	if e.Cause == nil {
+		return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+	}
+	return fmt.Sprintf("[%s] %s: %s", e.Code, e.Message, e.Cause.Error())
+}
+
+func (e CustomError) Wrap(err error) CustomError {
+	e.Cause = err
+	return e
+}
+
+func (e CustomError) Unwrap() error {
+	return e.Cause
+}

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -1,0 +1,54 @@
+package response
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/yhshin0/go-auth-server/internal/defs"
+)
+
+type Response struct {
+	Code    string `json:"code"` // e.g. SUCCESS, INVALID_CREDENTIALS
+	Data    any    `json:"data,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func GeneralResponse(w http.ResponseWriter, statusCode int, data any) {
+	const success = "SUCCESS"
+
+	write(w, statusCode, Response{Code: success, Data: data})
+}
+
+func ErrorResponse(w http.ResponseWriter, err error) {
+	const internalServerError = "INTERNAL_SERVER_ERROR"
+
+	statusCode := http.StatusInternalServerError
+	code := internalServerError
+	message := http.StatusText(http.StatusInternalServerError)
+
+	logLevel := slog.LevelError
+	var e defs.CustomError
+	if errors.As(err, &e) {
+		statusCode = e.StatusCode
+		code = e.Code
+		message = e.Message
+		logLevel = slog.LevelWarn
+	}
+	slog.Log(context.Background(), logLevel, err.Error())
+
+	write(w, statusCode, Response{Code: code, Message: message})
+}
+
+func write(w http.ResponseWriter, statusCode int, resp Response) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(statusCode)
+	b, _ := json.Marshal(resp)
+	w.Write(b)
+}
+
+func NoContentResponse(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}


### PR DESCRIPTION
## 내용
<!-- 이 PR을 머지하면 무엇이 달라지나요? -->
- 정해놓은 양식에 맞춰 response를 반환하는 헬퍼 함수 구현
- 커스텀 에러 자료형 구현

## 배경
<!-- 이 변경 없이 살 수도 있었는데, 왜 굳이 했나요? -->
- 해당 함수 구현으로 response 포맷을 맞추는 로직이 중복되지 않음
- ErrorResponse()를 통해 사용자에게 미리 정해놓은 에러만 반환할 수 있으며, 그 외의 함수는 500 에러로 받을 수 있음
- 커스텀 에러를 통해 특정 에러를 감싸서 사용자에게 불필요한 내용을 전달하지 않을 수 있음

## 관련 이슈

closes #13 
